### PR TITLE
Add MOTD placeholders and automate version management

### DIFF
--- a/EssC/essc/pom.xml
+++ b/EssC/essc/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>net.godlycow.org</groupId>
         <artifactId>EssentialsC-parent</artifactId>
-        <version>4.2.1</version>
+        <version>${revision}</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/EssC/essc/src/main/java/net/godlycow/org/essc/modules/MOTDManager.java
+++ b/EssC/essc/src/main/java/net/godlycow/org/essc/modules/MOTDManager.java
@@ -55,7 +55,11 @@ public class MOTDManager implements Listener {
     }
 
     private Component parseLine(String line, Player player) {
-        String processed = line.replace("<player>", player.getName());
+        String processed = line.replace("<player>", player.getName())
+                .replace("{PLAYER}", player.getName())
+                .replace("{player}", player.getName())
+                .replace("{ONLINE}", String.valueOf(Bukkit.getOnlinePlayers().size()))
+                .replace("{online}", String.valueOf(Bukkit.getOnlinePlayers().size()));
         processed = LegacyColorConverter.toMiniMessage(processed);
         try {
             return miniMessage.deserialize(processed);

--- a/EssC/essc/src/main/resources/config.yml
+++ b/EssC/essc/src/main/resources/config.yml
@@ -113,13 +113,13 @@ heal:
 #
 # Sends a message of the day to players when they join the server.
 # Each line is sent as a separate chat message.
-# MiniMessage formatting and the <player> placeholder are supported.
+# MiniMessage formatting and placeholders like <player>, {PLAYER}, and {ONLINE} are supported.
 
 motd:
   # Set to false to disable the MOTD entirely.
   enabled: true
 
-  # Lines sent to the player on join. Supports MiniMessage and <player>.
+  # Lines sent to the player on join. Supports MiniMessage, <player>, {PLAYER}, and {ONLINE}.
   lines:
     - "<gray>You can customize this message in config.yml."
     - "<gray>Set <white>motd.enabled</white><gray> to <red>false</red><gray> to disable it completely."

--- a/EssC/essc/src/main/resources/plugin.yml
+++ b/EssC/essc/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: EssentialsC
-version: '4.2.1'
+version: '${project.version}'
 main: net.godlycow.org.essc.EssentialsC
 api-version: '1.21'
 folia-supported: true

--- a/EssC/pom.xml
+++ b/EssC/pom.xml
@@ -9,7 +9,8 @@
     <parent>
         <groupId>net.godlycow.org</groupId>
         <artifactId>EssentialsC-parent</artifactId>
-        <version>4.2.1</version>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>EssentialsC-aggregator</artifactId>

--- a/EssC/test-api/pom.xml
+++ b/EssC/test-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>net.godlycow.org</groupId>
         <artifactId>EssentialsC-parent</artifactId>
-        <version>4.2.1</version>
+        <version>${revision}</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/EssC/test-api/src/main/resources/plugin.yml
+++ b/EssC/test-api/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: EssentialsCAPITest
-version: 1.0.0
+version: '${project.version}'
 main: net.godlycow.org.api.test.Main
 api-version: '1.21'
 depend: [EssentialsC]

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -8,7 +8,8 @@
   <parent>
     <groupId>net.godlycow.org</groupId>
     <artifactId>EssentialsC-parent</artifactId>
-    <version>4.2.1</version>
+    <version>${revision}</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>EssentialsC-api</artifactId>

--- a/api/src/main/resources/plugin.yml
+++ b/api/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: api
-version: '0.0.1'
+version: '${project.version}'
 main: net.godlycow.org.essc.api.EsscAPI
 api-version: '1.21'

--- a/expansions/EssentialsCProfiles/pom.xml
+++ b/expansions/EssentialsCProfiles/pom.xml
@@ -4,22 +4,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>net.godlycow.org</groupId>
   <artifactId>EssentialsCProfiles</artifactId>
-  <version>0.0.1</version>
   <packaging>jar</packaging>
 
   <name>EssentialsCProfiles</name>
 
-  <properties>
-    <java.version>21</java.version>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
-
   <parent>
     <groupId>net.godlycow.org</groupId>
     <artifactId>EssentialsC-parent</artifactId>
-    <version>4.2.1</version>
+    <version>${revision}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/expansions/EssentialsCProfiles/src/main/resources/plugin.yml
+++ b/expansions/EssentialsCProfiles/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: EssentialsCProfiles
-version: 2.0.0
+version: '${project.version}'
 main: net.godlycow.org.expansions.profiles.EssentialsCProfiles
 api-version: '1.21'
 author: _GodlyCow

--- a/expansions/mysqldatabaseexpansion/pom.xml
+++ b/expansions/mysqldatabaseexpansion/pom.xml
@@ -8,12 +8,11 @@
   <parent>
     <groupId>net.godlycow.org</groupId>
     <artifactId>EssentialsC-parent</artifactId>
-    <version>4.2.1</version>
+    <version>${revision}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>MySQLDatabaseExpansion</artifactId>
-  <version>1.0.0</version>
   <name>EssentialsC MySQL Database Expansion</name>
   <description>MySQL database expansion for EssentialsC</description>
   <packaging>jar</packaging>

--- a/expansions/mysqldatabaseexpansion/src/main/resources/plugin.yml
+++ b/expansions/mysqldatabaseexpansion/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: EssentialsC-MySQLExpansion
-version: 4.1.3
+version: '${project.version}'
 main: net.godlycow.org.essc.expansion.mysql.MySQLDatabaseExpansion
 api-version: "1.21"
 authors: [_GodlyCow]

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <!-- Change this version number to update the other poms -->
-        <revision>4.2.3</revision>
+        <revision>4.2.2</revision>
         <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>net.godlycow.org</groupId>
     <artifactId>EssentialsC-parent</artifactId>
-    <version>4.2.1</version>
+    <version>${revision}</version>
     <name>EssentialsC Parent</name>
     <description>Parent project for EssentialsC plugin and API</description>
     <packaging>pom</packaging>
@@ -20,6 +20,8 @@
     </modules>
 
     <properties>
+        <!-- Change this version number to update the other poms -->
+        <revision>4.2.3</revision>
         <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -99,8 +101,32 @@
     </dependencyManagement>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>plugin.yml</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>plugin.yml</exclude>
+                </excludes>
+            </resource>
+        </resources>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>2.16.2</version>
+                    <configuration>
+                        <generateBackupPoms>false</generateBackupPoms>
+                    </configuration>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
@@ -115,6 +141,10 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>


### PR DESCRIPTION
## Description
Describe what this PR does.

This PR adds two new placeholders to the MOTD in config.yml to display the player's name and the number of players online. Also, it allows the automation of the project version number being updated automatically in the plugin.yml and across all poms of the project. 

---

## Changes
- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation

---

## Testing
Describe how you tested this.

I added the two new placeholders in the motd section of the config.yml following this format. 

```motd:
  enabled: true
  file: motd.txt
  max-line-width: 50
  lines:
  - '<gray>Welcome to the <green>BusyBee Dev Server, <white>{PLAYER}<gray>, we''re very happy to have you with us!'
  - '<gray>Friends online: <green>{ONLINE}'
  ```

---

## 📸 Screenshots (if applicable)
Add screenshots here.

https://i.ibb.co/J8dhSCf/Screenshot-1.png

---

## Checklist
- [x] Code compiles
- [x] Tests pass
- [x] Follows project style
- [x] No unnecessary files included
