### PR TITLE
Java 25 / Gamemode cmd update

### DIFF
--- a/EssC/essc/pom.xml
+++ b/EssC/essc/pom.xml
@@ -52,6 +52,12 @@
         <repository>
             <id>skinsrestorer</id>
             <url>https://repo.skinsrestorer.net/repository/maven-public/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
 
     </repositories>
@@ -189,13 +195,8 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
                 <configuration>
-                    <release>${java.version}</release>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                    <compilerArgs>
-                        <arg>--enable-preview</arg>
-                    </compilerArgs>
+                    <release>${maven.compiler.release}</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/EssC/essc/src/main/java/net/godlycow/org/essc/bootstrap/registrar/CommandRegistrar.java
+++ b/EssC/essc/src/main/java/net/godlycow/org/essc/bootstrap/registrar/CommandRegistrar.java
@@ -132,11 +132,13 @@ public class CommandRegistrar {
         register("user",           new UserCommand(plugin));
         register("suicide",        new SuicideCommand(plugin));
         register("smite",          new SmiteCommand(plugin));
-        register("gm",             new GamemodeCommand(plugin, "gm"));
-        register("gms",            new GamemodeCommand(plugin, "gms"));
-        register("gmc",            new GamemodeCommand(plugin, "gmc"));
-        register("gmsp",           new GamemodeCommand(plugin, "gmsp"));
-        register("gma",            new GamemodeCommand(plugin, "gma"));
+        GamemodeCommand gamemodeCommand = new GamemodeCommand(plugin);
+        register("gm",             gamemodeCommand);
+        register("gamemode",       gamemodeCommand);
+        register("gms",            gamemodeCommand);
+        register("gmc",            gamemodeCommand);
+        register("gmsp",           gamemodeCommand);
+        register("gma",            gamemodeCommand);
         register("stonecutter",    new StonecutterCommand(plugin));
         register("unban-ip",       new UnbanIpCommand(plugin, punishmentManager));
 

--- a/EssC/essc/src/main/java/net/godlycow/org/essc/command/Command.java
+++ b/EssC/essc/src/main/java/net/godlycow/org/essc/command/Command.java
@@ -96,7 +96,7 @@ public abstract class Command implements CommandExecutor, TabCompleter {
         }
 
         try {
-            return execute(sender, args);
+            return execute(sender, label, args);
         } catch (Exception e) {
             sender.sendMessage(lang.get(sender, "error.internal"));
             plugin.debug("Exception in " + name + ": " + e.getMessage());
@@ -107,6 +107,10 @@ public abstract class Command implements CommandExecutor, TabCompleter {
 
     public abstract boolean execute(CommandSender sender, String[] args);
 
+    public boolean execute(CommandSender sender, String label, String[] args) {
+        return execute(sender, args);
+    }
+
     @Override
     public List<String> onTabComplete(org.bukkit.command.CommandSender sender, org.bukkit.command.Command command,
                                       String alias, String[] args) {
@@ -115,7 +119,7 @@ public abstract class Command implements CommandExecutor, TabCompleter {
         }
 
         if (args.length == 1) {
-            List<String> base = tabComplete(sender, args);
+            List<String> base = tabComplete(sender, alias, args);
             if (base == null) return null;
 
             String partial = args[0].toLowerCase();
@@ -127,11 +131,15 @@ public abstract class Command implements CommandExecutor, TabCompleter {
             return base;
         }
 
-        return tabComplete(sender, args);
+        return tabComplete(sender, alias, args);
     }
 
     public List<String> tabComplete(CommandSender sender, String[] args) {
         return Collections.emptyList();
+    }
+
+    public List<String> tabComplete(CommandSender sender, String alias, String[] args) {
+        return tabComplete(sender, args);
     }
 
     protected void sendHelp(CommandSender sender, String[] args) {

--- a/EssC/essc/src/main/java/net/godlycow/org/essc/command/admin/GamemodeCommand.java
+++ b/EssC/essc/src/main/java/net/godlycow/org/essc/command/admin/GamemodeCommand.java
@@ -13,39 +13,27 @@ import java.util.List;
 import java.util.Map;
 
 public class GamemodeCommand extends Command {
-
-    private static final Map<String, GameMode> NAME_TO_MODE = Map.of(
-            "gms",  GameMode.SURVIVAL,
-            "gmc",  GameMode.CREATIVE,
-            "gmsp", GameMode.SPECTATOR,
-            "gma",  GameMode.ADVENTURE
-    );
-
-    private static final Map<String, String> NAME_TO_PERMISSION = Map.of(
-            "gm",   "essentialsc.gamemode",
-            "gms",  "essentialsc.gamemode.survival",
-            "gmc",  "essentialsc.gamemode.creative",
-            "gmsp", "essentialsc.gamemode.spectator",
-            "gma",  "essentialsc.gamemode.adventure"
-    );
-
-    private final GameMode fixedMode;
-
-    public GamemodeCommand(EssentialsC plugin, String name) {
-        super(plugin, name, NAME_TO_PERMISSION.get(name), true, 0, "command.usage." + name);
-        this.fixedMode = NAME_TO_MODE.get(name);
+    
+    public GamemodeCommand(EssentialsC plugin) {
+        super(plugin, "gamemode", null, true, 0, "command.usage.gm");
     }
 
     @Override
     public boolean execute(CommandSender sender, String[] args) {
-        Player player = (Player) sender;
+        return execute(sender, "gamemode", args);
+    }
 
+    @Override
+    public boolean execute(CommandSender sender, String label, String[] args) {
+        Player player = (Player) sender;
         GameMode targetMode;
         Player target;
+        int targetArgIndex;
 
-        if (fixedMode != null) {
-            targetMode = fixedMode;
-            target = resolveTarget(player, args, 0);
+        targetMode = getModeFromLabel(label);
+
+        if (targetMode != null) {
+            targetArgIndex = 0;
         } else {
             if (args.length < 1) {
                 sendUsage(sender);
@@ -56,14 +44,21 @@ public class GamemodeCommand extends Command {
                 player.sendMessage(lang.get(player, "gamemode.invalid", Map.of("input", args[0])));
                 return true;
             }
-            target = resolveTarget(player, args, 1);
+            targetArgIndex = 1;
         }
 
+        String modePermission = "essentialsc.gamemode." + targetMode.name().toLowerCase();
+        if (!player.hasPermission(modePermission) && !player.hasPermission("essentialsc.gamemode")) {
+            player.sendMessage(lang.get(player, "error.no_permission"));
+            return true;
+        }
+
+        target = resolveTarget(player, args, targetArgIndex);
         if (target == null) {
             return true;
         }
 
-        if (target != player && !player.hasPermission(getPermission() + ".others")) {
+        if (target != player && !player.hasPermission(modePermission + ".others") && !player.hasPermission("essentialsc.gamemode.others")) {
             player.sendMessage(lang.get(player, "error.no_permission"));
             return true;
         }
@@ -87,6 +82,16 @@ public class GamemodeCommand extends Command {
 
         plugin.debug(player.getName() + " set gamemode of " + target.getName() + " to " + targetMode.name());
         return true;
+    }
+
+    private GameMode getModeFromLabel(String label) {
+        return switch (label.toLowerCase()) {
+            case "gms" -> GameMode.SURVIVAL;
+            case "gmc" -> GameMode.CREATIVE;
+            case "gmsp" -> GameMode.SPECTATOR;
+            case "gma" -> GameMode.ADVENTURE;
+            default -> null;
+        };
     }
 
     private Player resolveTarget(Player sender, String[] args, int argIndex) {
@@ -122,12 +127,22 @@ public class GamemodeCommand extends Command {
 
     @Override
     public List<String> tabComplete(CommandSender sender, String[] args) {
-        if (fixedMode != null) {
-            if (args.length == 1 && sender.hasPermission(getPermission() + ".others")) {
-                return plugin.getServer().getOnlinePlayers().stream()
-                        .map(Player::getName)
-                        .filter(name -> name.toLowerCase().startsWith(args[0].toLowerCase()))
-                        .toList();
+        return tabComplete(sender, "gamemode", args);
+    }
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String label, String[] args) {
+        GameMode mode = getModeFromLabel(label);
+
+        if (mode != null) {
+            if (args.length == 1) {
+                String modePermission = "essentialsc.gamemode." + mode.name().toLowerCase();
+                if (sender.hasPermission(modePermission + ".others") || sender.hasPermission("essentialsc.gamemode.others")) {
+                    return plugin.getServer().getOnlinePlayers().stream()
+                            .map(Player::getName)
+                            .filter(name -> name.toLowerCase().startsWith(args[0].toLowerCase()))
+                            .toList();
+                }
             }
             return Collections.emptyList();
         }
@@ -136,14 +151,21 @@ public class GamemodeCommand extends Command {
             List<String> modes = Arrays.asList("survival", "creative", "adventure", "spectator");
             return modes.stream()
                     .filter(m -> m.startsWith(args[0].toLowerCase()))
+                    .filter(m -> sender.hasPermission("essentialsc.gamemode." + m) || sender.hasPermission("essentialsc.gamemode"))
                     .toList();
         }
 
-        if (args.length == 2 && sender.hasPermission(getPermission() + ".others")) {
-            return plugin.getServer().getOnlinePlayers().stream()
-                    .map(Player::getName)
-                    .filter(name -> name.toLowerCase().startsWith(args[1].toLowerCase()))
-                    .toList();
+        if (args.length == 2) {
+            GameMode targetMode = parseGameMode(args[0]);
+            if (targetMode != null) {
+                String modePermission = "essentialsc.gamemode." + targetMode.name().toLowerCase();
+                if (sender.hasPermission(modePermission + ".others") || sender.hasPermission("essentialsc.gamemode.others")) {
+                    return plugin.getServer().getOnlinePlayers().stream()
+                            .map(Player::getName)
+                            .filter(name -> name.toLowerCase().startsWith(args[1].toLowerCase()))
+                            .toList();
+                }
+            }
         }
 
         return Collections.emptyList();

--- a/EssC/essc/src/main/resources/commands.yml
+++ b/EssC/essc/src/main/resources/commands.yml
@@ -517,6 +517,36 @@ stonecutter:
   priority: normal
   aliases: []
 
+gm:
+  enabled: true
+  priority: normal
+  aliases: []
+
+gamemode:
+  enabled: true
+  priority: normal
+  aliases: []
+
+gms:
+  enabled: true
+  priority: normal
+  aliases: []
+
+gmc:
+  enabled: true
+  priority: normal
+  aliases: []
+
+gmsp:
+  enabled: true
+  priority: normal
+  aliases: []
+
+gma:
+  enabled: true
+  priority: normal
+  aliases: []
+
 unban-ip:
   enabled: true
   priority: normal

--- a/EssC/essc/src/main/resources/plugin.yml
+++ b/EssC/essc/src/main/resources/plugin.yml
@@ -466,25 +466,30 @@ commands:
     usage: /gm <survival|creative|adventure|spectator> [player]
     permission: essentialsc.gamemode
 
+  gamemode:
+    description: Change your gamemode
+    usage: /gamemode <survival|creative|adventure|spectator> [player]
+    permission: essentialsc.gamemode
+
   gms:
     description: Switch to Survival mode
     usage: /gms [player]
-    permission: essentialsc.gamemode
+    permission: essentialsc.gamemode.survival
 
   gmc:
     description: Switch to Creative mode
     usage: /gmc [player]
-    permission: essentialsc.gamemode
+    permission: essentialsc.gamemode.creative
 
   gmsp:
     description: Switch to Spectator mode
     usage: /gmsp [player]
-    permission: essentialsc.gamemode
+    permission: essentialsc.gamemode.spectator
 
   gma:
     description: Switch to Adventure mode
     usage: /gma [player]
-    permission: essentialsc.gamemode
+    permission: essentialsc.gamemode.adventure
 
   stonecutter:
     description: Open a virtual stonecutter

--- a/EssC/test-api/pom.xml
+++ b/EssC/test-api/pom.xml
@@ -68,14 +68,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
-                <configuration>
-                    <release>${java.version}</release>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                    <compilerArgs>
-                        <arg>--enable-preview</arg>
-                    </compilerArgs>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/expansions/EssentialsCProfiles/pom.xml
+++ b/expansions/EssentialsCProfiles/pom.xml
@@ -22,15 +22,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.11.0</version>
-        <configuration>
-          <source>21</source>
-          <target>21</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.3.0</version>
         <configuration>

--- a/expansions/mysqldatabaseexpansion/pom.xml
+++ b/expansions/mysqldatabaseexpansion/pom.xml
@@ -59,15 +59,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.13.0</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.5.1</version>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -21,10 +21,8 @@
 
     <properties>
         <!-- Change this version number to update the other poms -->
-        <revision>4.2.2</revision>
-        <java.version>21</java.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <revision>4.2.3</revision>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <server.dir>${project.basedir}/run-server</server.dir>
@@ -132,8 +130,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.13.0</version>
                     <configuration>
-                        <source>${java.version}</source>
-                        <target>${java.version}</target>
+                        <release>${maven.compiler.release}</release>
                         <encoding>UTF-8</encoding>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
## Description
This pull request modernizes the project's build configuration and refactors the gamemode command system. 

Key changes include:
* **Build System Modernization:** Updated Maven POMs to use the modern `<maven.compiler.release>` property targeting Java 21 compatibility while building against a Java 25 environment. Cleaned up redundant `maven-compiler-plugin` configurations and optimized the SkinsRestorer repository settings by disabling unnecessary release and snapshot checks.
* **Command Refactoring:** Consolidated scattered gamemode subcommands into a single, centralized `GamemodeCommand` handler.
* **Feature Additions & Refinement:** Added shortcut commands for game modes to `plugin.yml`, refined associated permission nodes, and updated command registration and tab completion to support the new unified structure.

---

## Changes
- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Documentation

---

## Testing
Tested the plugin in a development environment to ensure:
* Successful compilation using the Java 25 toolchain with Java 21 bytecode compatibility.
* Proper registration and execution of the unified `/gamemode` command and its new shortcuts.
* Tab-completion logic correctly populates arguments according to the updated permission nodes.

---

## 📸 Screenshots (if applicable)
Add screenshots here.

---

## Checklist
- [X] Code compiles
- [X] Tests pass
- [X] Follows project style
- [X] No unnecessary files included