### PR TITLE
Fix starter kits not applied on first join

### DIFF
--- a/api/src/main/java/net/godlycow/org/essc/api/kit/event/KitDataLoadEvent.java
+++ b/api/src/main/java/net/godlycow/org/essc/api/kit/event/KitDataLoadEvent.java
@@ -12,6 +12,7 @@ public class KitDataLoadEvent extends Event {
     private final int loadedEntryCount;
 
     public KitDataLoadEvent(UUID playerId, String playerName, int loadedEntryCount) {
+        super(true);
         this.playerId = playerId;
         this.playerName = playerName;
         this.loadedEntryCount = loadedEntryCount;

--- a/plugin/src/main/java/net/godlycow/org/essc/modules/kit/KitManager.java
+++ b/plugin/src/main/java/net/godlycow/org/essc/modules/kit/KitManager.java
@@ -72,6 +72,8 @@ public class KitManager implements Listener {
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
 
+        final boolean isFirstJoin = !player.hasPlayedBefore();
+
         CompletableFuture<Void> dataFuture = data.loadPlayerData(player.getUniqueId());
         CompletableFuture<Void> notifFuture = cooldowns.loadNotificationsEnabled(player.getUniqueId());
 
@@ -79,7 +81,7 @@ public class KitManager implements Listener {
             plugin.getServer().getGlobalRegionScheduler().run(plugin, task -> {
                 if (!player.isOnline()) return;
 
-                if (!player.hasPlayedBefore()) {
+                if (isFirstJoin) {
                     plugin.debug("First join detected for " + player.getName() + ", checking first-join kits");
 
                     for (Kit kit : definitions.getKits()) {


### PR DESCRIPTION
Starter kits are not being applied when joining server for the first time.

Seems to be due to silent failure of KitDataLoadEvent.

    java.lang.IllegalStateException: KitDataLoadEvent may only be triggered synchronously.

## Description

This PR makes two changes:

- Make KitDataLoadEvent able to run async with super(true).
- Determine first join before async task to prevent race condition where the player appears to have already joined.

You may wish to solve the problem differently. Also could be worth adding error handling with .exceptionally so these async events don't fail silently.

---

## Changes
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

---

## Testing

1. Cloned main to machine.
2. Compiled new plugin.
3. rm -r data/plugins/EssentialsC/databases/
4. rm -r data/plugins/EssentialsC/backups/
5. rm -r data/world/players
6. Start server and connect to world as if for the first time.

[INFO]: [bootstrap] Running Java 25 (OpenJDK 64-Bit Server VM 25.0.3+9-LTS; Eclipse Adoptium Temurin-25.0.3+9) on Linux 6.8.0-137-generic (amd64)
[INFO]: [bootstrap] Loading Paper 26.2-112-main@c9e894d (2026-08-11) for Minecraft 26.2
[INFO]: [PluginInitializerManager] Paper plugins (1):
 - BedrockSkinRestorer (1.0.0)
[INFO]: [PluginInitializerManager] Bukkit plugins (11):
 - Chunky (1.5.3), CoreProtect (24.0), EssentialsC (4.2.7.1), Geyser-Spigot (2.11.1-SNAPSHOT), LuckPerms (5.5.71), PlaceholderAPI (2.12.3), Vault (2.20.2), ViaBackwards (5.11.0), ViaVersion (5.11.0), floodgate (2.2.5-SNAPSHOT (b140-8780fa4)), squaremap (1.3.15)

---

## Checklist
- [x] Code compiles
- [ ] Tests pass
- [ ] Follows project style
- [ ] No unnecessary files included
